### PR TITLE
Removed the specific error expectation on line 77

### DIFF
--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -43,7 +43,7 @@ describe './lib/tic_tac_toe.rb' do
 
   describe '#input_to_index' do
 
-    it 'convervets a user_input to an integer' do
+    it 'converts a user_input to an integer' do
       user_input = "1"
 
       expect(input_to_index(user_input)).to be_a(Integer)

--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -74,7 +74,7 @@ describe './lib/tic_tac_toe.rb' do
     it 'takes three arguments: board, position, and player token' do
       board = [" ", " ", " ", " ", " ", " ", " ", " ", " "]
 
-      expect{move(board, 0, "X")}.to_not raise_error(ArgumentError)
+      expect{move(board, 0, "X")}.to_not raise_error
     end
 
     it 'allows "X" player in the bottom right and "O" in the top left ' do


### PR DESCRIPTION
Fixed error that caused `'takes three arguments: board, position, and player token'` to pass immediately, even prior to the creation of a `#move` method. The expectation would pass unless an `ArgumentError` was raised, including when another exception -- such as a `NoMethodError` -- was raised.
